### PR TITLE
Fix compose paths and README typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   - Scalping
   - Swing Trading
   - Position Trading
-  - Swaping
+  - Swapping
   - Spot Trading
   - Pump and Dump
 
@@ -71,7 +71,7 @@
    - Edit the `config.json` file with your API keys and preferences.
 4. Run the bot:
    ```bash
-   python bot.py
+   python scripts/run_protocol.py
    ```
 
 ---
@@ -90,7 +90,7 @@
 
 ## 🔗 Supported Exchanges
 
-- Dex Sceener 
+- Dex Screener
 - Binance
 - Coinbase Pro
 - Kraken

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,22 +4,22 @@ services:
   protocol:
     container_name: trading-agent-core
     build:
-      context: ..
-      dockerfile: docker/Dockerfile
+      context: .
+      dockerfile: Dockerfile
     restart: always
     ports:
       - "5051:5051"
     env_file:
-      - ../.env
+      - ./.env
     volumes:
-      - ../v2_core:/app/v2_core
-      - ../data:/app/data
-      - ../scripts:/app/scripts
+      - ./v2_core:/app/v2_core
+      - ./data:/app/data
+      - ./scripts:/app/scripts
 
   dashboard:
     container_name: trading-agent-dashboard
     build:
-      context: ../dashboard-ui
+      context: ./dashboard-ui
       dockerfile: Dockerfile
     restart: always
     ports:


### PR DESCRIPTION
## Summary
- fix docker compose context paths
- correct README typos and update run command

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68741e1388b8832b88e1a246967632b3